### PR TITLE
Add Groovy DSL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,17 +6,17 @@ buildscript {
     }
     dependencies {
         classpath 'gradle.plugin.net.minecrell:licenser:0.3'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
     }
 }
 
 subprojects {
     apply plugin: 'java'
+    apply plugin: 'groovy'
     apply plugin: 'maven'
     apply plugin: 'net.minecrell.licenser'
 
-    sourceCompatibility = '1.8'
-    targetCompatibility = '1.8'
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
 
     group = 'org.cadixdev'
     archivesBaseName = project.name.toLowerCase()
@@ -32,8 +32,11 @@ subprojects {
     }
 
     dependencies {
-        testCompile 'org.junit.jupiter:junit-jupiter-api:5.2.0'
-        testRuntime 'org.junit.jupiter:junit-jupiter-engine:5.2.0'
+        testCompile "org.codehaus.groovy:groovy-all:$groovyVersion"
+        testCompile "org.spockframework:spock-core:$spockVersion"
+        testCompile "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+        testRuntime "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+        testRuntime "org.junit.vintage:junit-vintage-engine:$junitVersion"
     }
 
     test {

--- a/changelogs/0.6.0.md
+++ b/changelogs/0.6.0.md
@@ -9,3 +9,29 @@ mappings into their own configurations with ease.
 
 To use the GSON Module / JSON Format, simply add `org.cadixdev:lorenz-io-gson:0.6.0` to
 your build tool.
+
+## Groovy DSL
+
+Lorenz now has a Groovy DSL, that simplifies the creation of mappings.
+
+```groovy
+def EXTRA = new ExtensionKey(String, 'extra')
+
+def mappings = MappingSetDsl.create {
+    klass('a') {
+        deobf = 'Demo'
+        extension EXTRA, 'demo data'
+        
+        field('g') { deobf = 'name' }
+        
+        method('h', '(Z)Ljava/lang/String;') {
+            deobf = 'getName'
+            
+            param(0) { deobf = 'example' }
+        }
+    }
+}
+```
+
+To use the Groovy DSL, simply add `org.cadixdev:lorenz-dsl-groovy:0.6.0` to your build
+tool.

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,8 @@ url = https://www.jamiemansfield.me/projects/lorenz
 inceptionYear = 2016
 
 # Build Settings
+javaVersion = 1.8
+groovyVersion = 2.5.8
 bombeVersion = 0.4.0-SNAPSHOT
+junitVersion = 5.5.1
+spockVersion = 1.3-groovy-2.5

--- a/lorenz-dsl-groovy/build.gradle
+++ b/lorenz-dsl-groovy/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compileOnly 'org.codehaus.groovy:groovy:2.5.8'
+    compileOnly "org.codehaus.groovy:groovy:$groovyVersion"
     compile project(':lorenz')
 }
 

--- a/lorenz-dsl-groovy/build.gradle
+++ b/lorenz-dsl-groovy/build.gradle
@@ -1,0 +1,10 @@
+dependencies {
+    compileOnly 'org.codehaus.groovy:groovy:2.5.8'
+    compile project(':lorenz')
+}
+
+javadoc {
+    options.links(
+            'http://docs.groovy-lang.org/2.5.8/html/gapi/'
+    )
+}

--- a/lorenz-dsl-groovy/gradle.properties
+++ b/lorenz-dsl-groovy/gradle.properties
@@ -1,0 +1,4 @@
+name = Lorenz-DSL-Groovy
+description = A DSL for easing use of Lorenz within Groovy projects.
+url = https://www.jamiemansfield.me/projects/lorenz
+inceptionYear = 2019

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/ClassMappingDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/ClassMappingDsl.java
@@ -63,7 +63,7 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
             final String name, final FieldType type,
             @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MappingDsl.class) final Closure<?> script) {
         return DslUtil.delegate(
-                this.mapping.getOrCreateFieldMapping(new FieldSignature(name, type)),
+                this.mapping.getOrCreateFieldMapping(name, type),
                 MappingDsl::new, script);
     }
 
@@ -113,7 +113,7 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
             final String name, final MethodDescriptor desc,
             @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MethodMappingDsl.class) final Closure<?> script) {
         return DslUtil.delegate(
-                this.mapping.getOrCreateMethodMapping(new MethodSignature(name, desc)),
+                this.mapping.getOrCreateMethodMapping(name, desc),
                 MethodMappingDsl::new, script);
     }
 

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/ClassMappingDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/ClassMappingDsl.java
@@ -1,0 +1,160 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.dsl;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.cadixdev.bombe.type.FieldType;
+import org.cadixdev.bombe.type.MethodDescriptor;
+import org.cadixdev.bombe.type.signature.FieldSignature;
+import org.cadixdev.bombe.type.signature.MethodSignature;
+import org.cadixdev.lorenz.model.ClassMapping;
+import org.cadixdev.lorenz.model.FieldMapping;
+import org.cadixdev.lorenz.model.InnerClassMapping;
+import org.cadixdev.lorenz.model.MethodMapping;
+
+/**
+ * A DSL to simplify the manipulation of {@link ClassMapping}s in Groovy.
+ *
+ * @param <T> The type of the class mapping
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T> {
+
+    public ClassMappingDsl(final T mapping) {
+        super(mapping);
+    }
+
+    /**
+     * Creates a field mapping from the given name and field type, and applies
+     * the given {@link Closure} to it.
+     *
+     * @param name The name of the field
+     * @param type The type of the field
+     * @param script The closure to use
+     * @return The mapping
+     * @see ClassMapping#getOrCreateFieldMapping(FieldSignature)
+     */
+    public FieldMapping field(
+            final String name, final FieldType type,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
+        final FieldMapping mapping = this.mapping.getOrCreateFieldMapping(new FieldSignature(name, type));
+        script.setResolveStrategy(Closure.DELEGATE_FIRST);
+        script.setDelegate(new MappingDsl<>(mapping));
+        script.call();
+        return mapping;
+    }
+
+    /**
+     * Creates a field mapping from the given name and field type, and applies
+     * the given {@link Closure} to it.
+     *
+     * @param name The name of the field
+     * @param type The type of the field
+     * @param script The closure to use
+     * @return The mapping
+     * @see ClassMappingDsl#field(String, FieldType, Closure)
+     * @see FieldType#of(String)
+     */
+    public FieldMapping field(
+            final String name, final String type,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
+        return this.field(name, FieldType.of(type), script);
+    }
+
+    /**
+     * Creates a field mapping from the given name, and applies the given
+     * {@link Closure} to it.
+     *
+     * @param name The name of the field
+     * @param script The closure to use
+     * @return The mapping
+     * @see ClassMapping#getOrCreateFieldMapping(String)
+     */
+    public FieldMapping field(
+            final String name,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
+        return this.field(name, (FieldType) null, script);
+    }
+
+    /**
+     * Creates a method mapping for the given name and descriptor, and applies
+     * the given {@link Closure} to it.
+     *
+     * @param name The obfuscated name of the method
+     * @param desc The descriptor of the method
+     * @param script The closure to use
+     * @return The mapping
+     * @see ClassMapping#getOrCreateMethodMapping(MethodSignature)
+     */
+    public MethodMapping method(
+            final String name, final MethodDescriptor desc,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MethodMappingDsl.class) final Closure<?> script) {
+        final MethodMapping mapping = this.mapping.getOrCreateMethodMapping(new MethodSignature(name, desc));
+        script.setResolveStrategy(Closure.DELEGATE_FIRST);
+        script.setDelegate(new MethodMappingDsl(mapping));
+        script.call();
+        return mapping;
+    }
+
+    /**
+     * Creates a method mapping for the given name and descriptor, and applies
+     * the given {@link Closure} to it.
+     *
+     * @param name The obfuscated name of the method
+     * @param desc The descriptor of the method
+     * @param script The closure to use
+     * @return The mapping
+     * @see ClassMappingDsl#method(String, MethodDescriptor, Closure)
+     * @see MethodDescriptor#of(String)
+     */
+    public MethodMapping method(
+            final String name, final String desc,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MethodMappingDsl.class) final Closure<?> script) {
+        return this.method(name, MethodDescriptor.of(desc), script);
+    }
+
+    /**
+     * Creates a inner class mapping of the given name, and applies
+     * the given {@link Closure} to it.
+     *
+     * @param name The obfuscated name of the class
+     * @param script The closure to use
+     * @return The mapping
+     * @see ClassMapping#getOrCreateInnerClassMapping(String)
+     */
+    public InnerClassMapping klass(
+            final String name,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = ClassMappingDsl.class) final Closure<?> script) {
+        final InnerClassMapping mapping = this.mapping.getOrCreateInnerClassMapping(name);
+        script.setResolveStrategy(Closure.DELEGATE_FIRST);
+        script.setDelegate(new ClassMappingDsl<>(mapping));
+        script.call();
+        return mapping;
+    }
+
+}

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/ClassMappingDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/ClassMappingDsl.java
@@ -61,12 +61,10 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
      */
     public FieldMapping field(
             final String name, final FieldType type,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
-        final FieldMapping mapping = this.mapping.getOrCreateFieldMapping(new FieldSignature(name, type));
-        script.setResolveStrategy(Closure.DELEGATE_FIRST);
-        script.setDelegate(new MappingDsl<>(mapping));
-        script.call();
-        return mapping;
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MappingDsl.class) final Closure<?> script) {
+        return DslUtil.delegate(
+                this.mapping.getOrCreateFieldMapping(new FieldSignature(name, type)),
+                MappingDsl::new, script);
     }
 
     /**
@@ -82,7 +80,7 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
      */
     public FieldMapping field(
             final String name, final String type,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MappingDsl.class) final Closure<?> script) {
         return this.field(name, FieldType.of(type), script);
     }
 
@@ -97,7 +95,7 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
      */
     public FieldMapping field(
             final String name,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MappingDsl.class) final Closure<?> script) {
         return this.field(name, (FieldType) null, script);
     }
 
@@ -113,12 +111,10 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
      */
     public MethodMapping method(
             final String name, final MethodDescriptor desc,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MethodMappingDsl.class) final Closure<?> script) {
-        final MethodMapping mapping = this.mapping.getOrCreateMethodMapping(new MethodSignature(name, desc));
-        script.setResolveStrategy(Closure.DELEGATE_FIRST);
-        script.setDelegate(new MethodMappingDsl(mapping));
-        script.call();
-        return mapping;
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MethodMappingDsl.class) final Closure<?> script) {
+        return DslUtil.delegate(
+                this.mapping.getOrCreateMethodMapping(new MethodSignature(name, desc)),
+                MethodMappingDsl::new, script);
     }
 
     /**
@@ -134,7 +130,7 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
      */
     public MethodMapping method(
             final String name, final String desc,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MethodMappingDsl.class) final Closure<?> script) {
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MethodMappingDsl.class) final Closure<?> script) {
         return this.method(name, MethodDescriptor.of(desc), script);
     }
 
@@ -149,12 +145,10 @@ public class ClassMappingDsl<T extends ClassMapping<?, ?>> extends MappingDsl<T>
      */
     public InnerClassMapping klass(
             final String name,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = ClassMappingDsl.class) final Closure<?> script) {
-        final InnerClassMapping mapping = this.mapping.getOrCreateInnerClassMapping(name);
-        script.setResolveStrategy(Closure.DELEGATE_FIRST);
-        script.setDelegate(new ClassMappingDsl<>(mapping));
-        script.call();
-        return mapping;
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = ClassMappingDsl.class) final Closure<?> script) {
+        return DslUtil.delegate(
+                this.mapping.getOrCreateInnerClassMapping(name),
+                ClassMappingDsl::new, script);
     }
 
 }

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/DslUtil.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/DslUtil.java
@@ -26,37 +26,31 @@
 package org.cadixdev.lorenz.dsl;
 
 import groovy.lang.Closure;
-import groovy.lang.DelegatesTo;
-import org.cadixdev.lorenz.model.MethodMapping;
-import org.cadixdev.lorenz.model.MethodParameterMapping;
+
+import java.util.function.Function;
 
 /**
- * A DSL to simplify the manipulation of {@link MethodMapping}s in Groovy.
+ * Internal utility functions for the Lorenz Groovy DSL.
  *
  * @author Jamie Mansfield
  * @since 0.6.0
  */
-public class MethodMappingDsl extends MappingDsl<MethodMapping> {
+class DslUtil {
 
-    public MethodMappingDsl(final MethodMapping mapping) {
-        super(mapping);
+    static final int RESOLVE_STRATEGY = Closure.DELEGATE_FIRST;
+
+    static void setupAndCallDelegateClosure(final Object delegate, final Closure<?> script) {
+        script.setResolveStrategy(DslUtil.RESOLVE_STRATEGY);
+        script.setDelegate(delegate);
+        script.call();
     }
 
-    /**
-     * Creates a method parameter mapping for the given index,
-     * and applies the given {@link Closure} to it.
-     *
-     * @param index The index of the parameter
-     * @param script The closure to use
-     * @return The mapping
-     * @see MethodMapping#getOrCreateParameterMapping(int)
-     */
-    public MethodParameterMapping param(
-            final int index,
-            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MappingDsl.class) final Closure<?> script) {
-        return DslUtil.delegate(
-                this.mapping.getOrCreateParameterMapping(index),
-                MappingDsl::new, script);
+    static <T> T delegate(final T obj, final Function<T, Object> delegate, final Closure<?> script) {
+        setupAndCallDelegateClosure(delegate.apply(obj), script);
+        return obj;
+    }
+
+    private DslUtil() {
     }
 
 }

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MappingDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MappingDsl.java
@@ -1,0 +1,71 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.dsl;
+
+import org.cadixdev.lorenz.model.ExtensionKey;
+import org.cadixdev.lorenz.model.Mapping;
+
+/**
+ * A DSL to simplify the manipulation of {@link Mapping}s in Groovy.
+ *
+ * @param <T> The type of the mapping
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public class MappingDsl<T extends Mapping<?, ?>> {
+
+    /**
+     * The mapping manipulated by this DSL.
+     */
+    protected final T mapping;
+
+    public MappingDsl(final T mapping) {
+        this.mapping = mapping;
+    }
+
+    /**
+     * Sets the de-obfuscated name of the mapping.
+     *
+     * @param name The de-obfuscated name
+     * @see Mapping#setDeobfuscatedName(String)
+     */
+    public void setDeobf(final String name) {
+        this.mapping.setDeobfuscatedName(name);
+    }
+
+    /**
+     * Adds the given extension data to the mapping.
+     *
+     * @param key The extension key
+     * @param value The value of the extension
+     * @param <K> The type of the extension data
+     * @see Mapping#set(ExtensionKey, Object)
+     */
+    public <K> void extension(final ExtensionKey<K> key, final K value) {
+        this.mapping.set(key, value);
+    }
+
+}

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MappingSetDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MappingSetDsl.java
@@ -45,12 +45,8 @@ public class MappingSetDsl {
      * @return The mapping set
      * @see MappingSet#create()
      */
-    public static MappingSet create(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingSetDsl.class) final Closure<?> script) {
-        final MappingSet mappings = MappingSet.create();
-        script.setResolveStrategy(Closure.DELEGATE_FIRST);
-        script.setDelegate(new MappingSetDsl(mappings));
-        script.call();
-        return mappings;
+    public static MappingSet create(@DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = MappingSetDsl.class) final Closure<?> script) {
+        return DslUtil.delegate(MappingSet.create(), MappingSetDsl::new, script);
     }
 
     private final MappingSet mappings;
@@ -70,12 +66,10 @@ public class MappingSetDsl {
      */
     public TopLevelClassMapping klass(
             final String name,
-            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = ClassMappingDsl.class) final Closure<?> script) {
-        final TopLevelClassMapping mapping = this.mappings.getOrCreateTopLevelClassMapping(name);
-        script.setResolveStrategy(Closure.DELEGATE_FIRST);
-        script.setDelegate(new ClassMappingDsl<>(mapping));
-        script.call();
-        return mapping;
+            @DelegatesTo(strategy = DslUtil.RESOLVE_STRATEGY, value = ClassMappingDsl.class) final Closure<?> script) {
+        return DslUtil.delegate(
+                this.mappings.getOrCreateTopLevelClassMapping(name),
+                ClassMappingDsl::new, script);
     }
 
 }

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MappingSetDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MappingSetDsl.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.dsl;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.cadixdev.lorenz.MappingSet;
+import org.cadixdev.lorenz.model.TopLevelClassMapping;
+
+/**
+ * A DSL to simplify the creation of {@link MappingSet}s in Groovy.
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public class MappingSetDsl {
+
+    /**
+     * Creates a mapping set, and applies the given {@link Closure} to it.
+     *
+     * @param script The closure to use
+     * @return The mapping set
+     * @see MappingSet#create()
+     */
+    public static MappingSet create(@DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingSetDsl.class) final Closure<?> script) {
+        final MappingSet mappings = MappingSet.create();
+        script.setResolveStrategy(Closure.DELEGATE_FIRST);
+        script.setDelegate(new MappingSetDsl(mappings));
+        script.call();
+        return mappings;
+    }
+
+    private final MappingSet mappings;
+
+    public MappingSetDsl(final MappingSet mappings) {
+        this.mappings = mappings;
+    }
+
+    /**
+     * Creates a top-level class mapping of the given name, and applies
+     * the given {@link Closure} to it.
+     *
+     * @param name The obfuscated name of the class
+     * @param script The closure to use
+     * @return The mapping
+     * @see MappingSet#getOrCreateTopLevelClassMapping(String)
+     */
+    public TopLevelClassMapping klass(
+            final String name,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = ClassMappingDsl.class) final Closure<?> script) {
+        final TopLevelClassMapping mapping = this.mappings.getOrCreateTopLevelClassMapping(name);
+        script.setResolveStrategy(Closure.DELEGATE_FIRST);
+        script.setDelegate(new ClassMappingDsl<>(mapping));
+        script.call();
+        return mapping;
+    }
+
+}

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MethodMappingDsl.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/MethodMappingDsl.java
@@ -1,0 +1,64 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.dsl;
+
+import groovy.lang.Closure;
+import groovy.lang.DelegatesTo;
+import org.cadixdev.lorenz.model.MethodMapping;
+import org.cadixdev.lorenz.model.MethodParameterMapping;
+
+/**
+ * A DSL to simplify the manipulation of {@link MethodMapping}s in Groovy.
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public class MethodMappingDsl extends MappingDsl<MethodMapping> {
+
+    public MethodMappingDsl(final MethodMapping mapping) {
+        super(mapping);
+    }
+
+    /**
+     * Creates a method parameter mapping for the given index,
+     * and applies the given {@link Closure} to it.
+     *
+     * @param index The index of the parameter
+     * @param script The closure to use
+     * @return The mapping
+     * @see MethodMapping#getOrCreateParameterMapping(int)
+     */
+    public MethodParameterMapping param(
+            final int index,
+            @DelegatesTo(strategy = Closure.DELEGATE_FIRST, value = MappingDsl.class) final Closure<?> script) {
+        final MethodParameterMapping mapping = this.mapping.getOrCreateParameterMapping(index);
+        script.setResolveStrategy(Closure.DELEGATE_FIRST);
+        script.setDelegate(new MappingDsl<>(mapping));
+        script.call();
+        return mapping;
+    }
+
+}

--- a/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/package-info.java
+++ b/lorenz-dsl-groovy/src/main/java/org/cadixdev/lorenz/dsl/package-info.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * A Groovy DSL, that simplifies the creation of Lorenz mappings.
+ *
+ * <pre>
+ *     def mappings = MappingSetDsl.create {
+ *         klass('a') {
+ *             deobf = 'Demo'
+ *             extension EXTRA, 'a.class'
+ *             field('g') { deobf = 'name' }
+ *             method('h', '()Ljava/lang/String;') { deobf = 'getName' }
+ *         }
+ *     }
+ * </pre>
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+package org.cadixdev.lorenz.dsl;

--- a/lorenz-dsl-groovy/src/test/groovy/org/cadixdev/lorenz/dsl/test/MappingSetDslSpec.groovy
+++ b/lorenz-dsl-groovy/src/test/groovy/org/cadixdev/lorenz/dsl/test/MappingSetDslSpec.groovy
@@ -29,6 +29,7 @@ import org.cadixdev.lorenz.MappingSet
 import org.cadixdev.lorenz.dsl.MappingSetDsl
 import org.cadixdev.lorenz.model.ExtensionKey
 import org.cadixdev.lorenz.model.FieldMapping
+import org.cadixdev.lorenz.model.InnerClassMapping
 import org.cadixdev.lorenz.model.MethodMapping
 import org.cadixdev.lorenz.model.MethodParameterMapping
 import org.cadixdev.lorenz.model.TopLevelClassMapping
@@ -56,6 +57,9 @@ class MappingSetDslSpec extends Specification {
             klass('b') {
                 deobf = 'Demo'
                 extension TEST, 'Hello, World!'
+                klass('e') {
+                    deobf = 'Inner'
+                }
             }
         }
 
@@ -87,6 +91,11 @@ class MappingSetDslSpec extends Specification {
         final Optional<String> testData = b.get(TEST)
         testData.isPresent()
         testData.get() == 'Hello, World!'
+        // b$e.class
+        b.innerClassMappings.size() == 1
+        final InnerClassMapping b$e = b.innerClassMappings[0]
+        b$e.obfuscatedName == 'e'
+        b$e.deobfuscatedName == 'Inner'
     }
 
 }

--- a/lorenz-dsl-groovy/src/test/groovy/org/cadixdev/lorenz/dsl/test/MappingSetDslSpec.groovy
+++ b/lorenz-dsl-groovy/src/test/groovy/org/cadixdev/lorenz/dsl/test/MappingSetDslSpec.groovy
@@ -1,0 +1,92 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.dsl.test
+
+import org.cadixdev.lorenz.MappingSet
+import org.cadixdev.lorenz.dsl.MappingSetDsl
+import org.cadixdev.lorenz.model.ExtensionKey
+import org.cadixdev.lorenz.model.FieldMapping
+import org.cadixdev.lorenz.model.MethodMapping
+import org.cadixdev.lorenz.model.MethodParameterMapping
+import org.cadixdev.lorenz.model.TopLevelClassMapping
+import spock.lang.Specification
+
+class MappingSetDslSpec extends Specification {
+
+    static def TEST = new ExtensionKey(String, 'test')
+
+    def "creates mapping set"() {
+        given:
+        final MappingSet mappings = MappingSetDsl.create {
+            klass('a') {
+                deobf = 'Example'
+                field('c') {
+                    deobf = 'name'
+                }
+                method('d', '(Z)Ljava/lang/String;') {
+                    deobf = 'getName'
+                    param(0) {
+                        deobf = 'propagate'
+                    }
+                }
+            }
+            klass('b') {
+                deobf = 'Demo'
+                extension TEST, 'Hello, World!'
+            }
+        }
+
+        expect:
+        mappings.topLevelClassMappings.size() == 2
+
+        // a.class
+        final TopLevelClassMapping a = mappings.topLevelClassMappings[0]
+        a.obfuscatedName == 'a'
+        a.deobfuscatedName == 'Example'
+        a.fieldMappings.size() == 1
+        final FieldMapping c = a.fieldMappings[0]
+        c.obfuscatedName == 'c'
+        c.deobfuscatedName == 'name'
+        !c.type.isPresent()
+        a.methodMappings.size() == 1
+        final MethodMapping d = a.methodMappings[0]
+        d.obfuscatedName == 'd'
+        d.deobfuscatedName == 'getName'
+        d.parameterMappings.size() == 1
+        final MethodParameterMapping d0 = d.parameterMappings[0]
+        d0.index == 0
+        d0.deobfuscatedName == 'propagate'
+
+        // b.class
+        final TopLevelClassMapping b = mappings.topLevelClassMappings[1]
+        b.obfuscatedName == 'b'
+        b.deobfuscatedName == 'Demo'
+        final Optional<String> testData = b.get(TEST)
+        testData.isPresent()
+        testData.get() == 'Hello, World!'
+    }
+
+}

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/ClassMapping.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/ClassMapping.java
@@ -28,6 +28,7 @@ package org.cadixdev.lorenz.model;
 import org.cadixdev.bombe.analysis.InheritanceCompletable;
 import org.cadixdev.bombe.analysis.InheritanceProvider;
 import org.cadixdev.bombe.type.FieldType;
+import org.cadixdev.bombe.type.MethodDescriptor;
 import org.cadixdev.bombe.type.signature.FieldSignature;
 import org.cadixdev.bombe.type.signature.MethodSignature;
 
@@ -172,7 +173,7 @@ public interface ClassMapping<M extends ClassMapping, P> extends Mapping<M, P>, 
      * @return The field mapping
      */
     default FieldMapping createFieldMapping(final String obfuscatedName, final String deobfuscatedName) {
-        return this.createFieldMapping(new FieldSignature(obfuscatedName, (FieldType) null), deobfuscatedName);
+        return this.createFieldMapping(new FieldSignature(obfuscatedName), deobfuscatedName);
     }
 
     /**
@@ -237,6 +238,19 @@ public interface ClassMapping<M extends ClassMapping, P> extends Mapping<M, P>, 
     }
 
     /**
+     * Gets, or creates should it not exist, a field mapping of the
+     * given signature.
+     *
+     * @param obfuscatedName The obfuscated name of the field mapping
+     * @param obfuscatedDescriptor The obfuscated descriptor of the field mapping
+     * @return The field mapping
+     * @since 0.6.0
+     */
+    default FieldMapping getOrCreateFieldMapping(final String obfuscatedName, final FieldType obfuscatedDescriptor) {
+        return this.getOrCreateFieldMapping(new FieldSignature(obfuscatedName, obfuscatedDescriptor));
+    }
+
+    /**
      * Establishes whether the class mapping contains a field mapping
      * of the given signature.
      *
@@ -258,7 +272,7 @@ public interface ClassMapping<M extends ClassMapping, P> extends Mapping<M, P>, 
      *         {@code false} otherwise
      */
     default boolean hasFieldMapping(final String obfuscatedName) {
-        return this.hasFieldMapping(new FieldSignature(obfuscatedName, null));
+        return this.hasFieldMapping(new FieldSignature(obfuscatedName));
     }
 
     /**
@@ -325,6 +339,19 @@ public interface ClassMapping<M extends ClassMapping, P> extends Mapping<M, P>, 
     }
 
     /**
+     * Creates a new method mapping, attached to this class mapping, using
+     * the given obfuscated method name and descriptor.
+     *
+     * @param obfuscatedName The obfuscated method name
+     * @param obfuscatedDescriptor The obfuscated method descriptor
+     * @return The method mapping
+     * @since 0.6.0
+     */
+    default MethodMapping createMethodMapping(final String obfuscatedName, final MethodDescriptor obfuscatedDescriptor) {
+        return this.createMethodMapping(new MethodSignature(obfuscatedName, obfuscatedDescriptor));
+    }
+
+    /**
      * Gets, or creates should it not exist, a method mapping of the
      * given obfuscated signature.
      *
@@ -346,6 +373,19 @@ public interface ClassMapping<M extends ClassMapping, P> extends Mapping<M, P>, 
      */
     default MethodMapping getOrCreateMethodMapping(final String obfuscatedName, final String obfuscatedDescriptor) {
         return this.getOrCreateMethodMapping(MethodSignature.of(obfuscatedName, obfuscatedDescriptor));
+    }
+
+    /**
+     * Gets, or creates should it not exist, a method mapping of the
+     * given obfuscated name, and descriptor.
+     *
+     * @param obfuscatedName The obfuscated name of the method mapping
+     * @param obfuscatedDescriptor The obfuscated descriptor of the method mapping
+     * @return The method mapping
+     * @since 0.6.0
+     */
+    default MethodMapping getOrCreateMethodMapping(final String obfuscatedName, final MethodDescriptor obfuscatedDescriptor) {
+        return this.getOrCreateMethodMapping(new MethodSignature(obfuscatedName, obfuscatedDescriptor));
     }
 
     /**

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = name
 include 'lorenz'
 include 'lorenz-asm'
+include 'lorenz-dsl-groovy'
 include 'lorenz-io-enigma'
 include 'lorenz-io-gson'
 include 'lorenz-io-jam'


### PR DESCRIPTION
```groovy
def EXTRA = new ExtensionKey(String, 'extra')

def mappings = MappingSetDsl.create {
    klass('a') {
        deobf = 'Demo'
        extension EXTRA, 'demo data'
        
        field('g') { deobf = 'name' }
        
        method('h', '(Z)Ljava/lang/String;') {
            deobf = 'getName'
            
            param(0) { deobf = 'example' }
        }
    }
}
```

**For future reference**:
This was written in Java, as it makes types easier, and the produced bytecode is much cleaner and efficient.

For historical value, https://gist.github.com/jamierocks/169d03318b8783df1b9a65d81bfbd5e5 is the beginnings of how the Groovy version would have turned out.