### PR TITLE
Mapping Model v2

### DIFF
--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/container/MappingContainer.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/container/MappingContainer.java
@@ -1,0 +1,91 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.model.container;
+
+import org.cadixdev.lorenz.model.Mapping;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * A container of {@link Mapping mappings} identified by a signature.
+ *
+ * <p>Mapping Containers allow for easy code reuse, reducing code,
+ * and making convenience methods more easily visible (and therefore
+ * maintainable).
+ *
+ * <p>If the container is used a field, rather than apart the model it
+ * backs, then {@link ParentedMappingContainer} should be used to allow
+ * for fluent operations.
+ *
+ * @param <M> The type of mapping contained
+ * @param <S> The type of the signature, representing the mapping
+ *
+ * @see ParentedMappingContainer
+ * @see SimpleParentedMappingContainer
+ * @see MethodContainer
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public interface MappingContainer<M extends Mapping<?, ?>, S> {
+
+    /**
+     * Gets an <strong>immutable</strong> view of all the mappings in
+     * the container.
+     *
+     * @return The mappings
+     */
+    Collection<M> getAll();
+
+    /**
+     * Checks whether the container contains a mapping of the given
+     * signature.
+     *
+     * @param signature The signature of the mapping
+     * @return {@code true} if there is a mapping for the signature;
+     *         {@code false} otherwise
+     */
+    boolean has(final S signature);
+
+    /**
+     * Gets the mapping, should it exist, of the given signature.
+     *
+     * @param signature The signature of the mapping
+     * @return The mapping, wrapped in an {@link Optional}
+     */
+    Optional<M> get(final S signature);
+
+    /**
+     * Gets, or creates if it doesn't exist, a mapping for the given
+     * signature.
+     *
+     * @param signature The signature of the mapping
+     * @return The mapping
+     */
+    M getOrCreate(final S signature);
+
+}

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/container/MethodContainer.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/container/MethodContainer.java
@@ -1,0 +1,109 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.model.container;
+
+import org.cadixdev.bombe.type.MethodDescriptor;
+import org.cadixdev.bombe.type.signature.MethodSignature;
+import org.cadixdev.lorenz.impl.model.MethodMappingImpl;
+import org.cadixdev.lorenz.model.ClassMapping;
+import org.cadixdev.lorenz.model.MethodMapping;
+
+import java.util.Optional;
+
+/**
+ * A container of {@link MethodMapping method mappings}, identified
+ * by their {@link MethodSignature signature}, and parented by a
+ * {@link ClassMapping class mapping}.
+ *
+ * @param <P> The type of class mapping, the parent is
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public class MethodContainer<P extends ClassMapping<?, ?>>
+        extends SimpleParentedMappingContainer<MethodMapping, MethodSignature, P> {
+
+    public MethodContainer(final P parent) {
+        super(parent, (p, signature) -> new MethodMappingImpl(p, signature, signature.getName()));
+    }
+
+    /**
+     * Gets, should it exist, the method mapping of the given obfuscated
+     * name and {@link MethodDescriptor descriptor}.
+     *
+     * @param obfuscatedName The name of the method
+     * @param obfuscatedDescriptor The descriptor of the method
+     * @return The mapping, wrapped in an {@link Optional}
+     *
+     * @see MappingContainer#get(Object)
+     */
+    public Optional<MethodMapping> get(final String obfuscatedName, final MethodDescriptor obfuscatedDescriptor) {
+        return this.get(new MethodSignature(obfuscatedName, obfuscatedDescriptor));
+    }
+
+    /**
+     * Gets, should it exist, the method mapping of the given obfuscated
+     * name and {@link MethodDescriptor descriptor}.
+     *
+     * @param obfuscatedName The name of the method
+     * @param obfuscatedDescriptor The descriptor of the method
+     * @return The mapping, wrapped in an {@link Optional}
+     *
+     * @see MappingContainer#get(Object)
+     */
+    public Optional<MethodMapping> get(final String obfuscatedName, final String obfuscatedDescriptor) {
+        return this.get(obfuscatedName, MethodDescriptor.of(obfuscatedDescriptor));
+    }
+
+    /**
+     * Gets, or creates if needed, the method mapping of the given
+     * obfuscated name and {@link MethodDescriptor descriptor}.
+     *
+     * @param obfuscatedName The name of the method
+     * @param obfuscatedDescriptor The descriptor of the method
+     * @return The mapping
+     * 
+     * @see MappingContainer#getOrCreate(Object)
+     */
+    public MethodMapping getOrCreate(final String obfuscatedName, final MethodDescriptor obfuscatedDescriptor) {
+        return this.getOrCreate(new MethodSignature(obfuscatedName, obfuscatedDescriptor));
+    }
+
+    /**
+     * Gets, or creates if needed, the method mapping of the given
+     * obfuscated name and {@link MethodDescriptor descriptor}.
+     *
+     * @param obfuscatedName The name of the method
+     * @param obfuscatedDescriptor The descriptor of the method
+     * @return The mapping
+     *
+     * @see MappingContainer#getOrCreate(Object)
+     */
+    public MethodMapping getOrCreate(final String obfuscatedName, final String obfuscatedDescriptor) {
+        return this.getOrCreate(obfuscatedName, MethodDescriptor.of(obfuscatedDescriptor));
+    }
+
+}

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/container/ParentedMappingContainer.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/container/ParentedMappingContainer.java
@@ -1,0 +1,59 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.model.container;
+
+import org.cadixdev.lorenz.model.Mapping;
+
+/**
+ * A {@link MappingContainer container} of {@link Mapping mappings}
+ * identified by signature, and parented by another object.
+ *
+ * <p><strong>A parented container should only be used where the
+ * container is separate from the parent object!</strong>
+ *
+ * @param <M> The type of mapping contained
+ * @param <S> The type of the signature, representing the mapping
+ * @param <P> The type of the parent object
+ *
+ * @see SimpleParentedMappingContainer
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public interface ParentedMappingContainer<M extends Mapping<?, ?>, S, P> extends MappingContainer<M, S> {
+
+    /**
+     * Gets the parent object, of the mappings contained in the
+     * container.
+     *
+     * <p><em>This is named back, as it is used heavily in fluent
+     * chain operations.</em>
+     *
+     * @return The parent object
+     */
+    P back();
+
+}

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/container/SimpleParentedMappingContainer.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/container/SimpleParentedMappingContainer.java
@@ -1,0 +1,86 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.model.container;
+
+import org.cadixdev.lorenz.model.Mapping;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiFunction;
+
+/**
+ * A simple implementation of {@link ParentedMappingContainer}, for
+ * mappings that have straight-forward relationships with their
+ * signatures.
+ *
+ * @param <M> The type of mapping contained
+ * @param <S> The type of the signature, representing the mapping
+ * @param <P> The type of the parent object
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+public abstract class SimpleParentedMappingContainer<M extends Mapping<?, ?>, S, P>
+        implements ParentedMappingContainer<M, S, P> {
+
+    private final P parent;
+    private final BiFunction<P, S, M> constructor;
+    private final Map<S, M> mappings = new HashMap<>();
+
+    public SimpleParentedMappingContainer(final P parent, final BiFunction<P, S, M> constructor) {
+        this.parent = parent;
+        this.constructor = constructor;
+    }
+
+    @Override
+    public Collection<M> getAll() {
+        return Collections.unmodifiableCollection(this.mappings.values());
+    }
+
+    @Override
+    public boolean has(final S signature) {
+        return this.mappings.containsKey(signature);
+    }
+
+    @Override
+    public Optional<M> get(final S signature) {
+        return Optional.ofNullable(this.mappings.get(signature));
+    }
+
+    @Override
+    public M getOrCreate(final S signature) {
+        return this.mappings.computeIfAbsent(signature, (sig) -> this.constructor.apply(this.parent, sig));
+    }
+
+    @Override
+    public P back() {
+        return this.parent;
+    }
+
+}

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/container/package-info.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/container/package-info.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Provides containers for {@link org.cadixdev.lorenz.model.Mapping mappings},
+ * identified by signatures - standardising access and manipulation there-of.
+ *
+ * <p>The benefit of having {@link org.cadixdev.lorenz.model.container.MappingContainer mapping containers}
+ * is that access to mappings all across Lorenz is done in a consistent way,
+ * and specialised convenience code is separate and easily visible (and
+ * therefore maintainable).
+ *
+ * <p>Consumers will either use {@link org.cadixdev.lorenz.model.container.MappingContainer}
+ * or {@link org.cadixdev.lorenz.model.container.ParentedMappingContainer},
+ * determined by whether their container is the same object as the mapping
+ * parent (in that case, use a mapping container).
+ *
+ * @author Jamie Mansfield
+ * @since 0.6.0
+ */
+package org.cadixdev.lorenz.model.container;


### PR DESCRIPTION
This pull request contains the work to overhaul Lorenz's mapping model, with some key aims:
1. Increase code reuse through the model.
2. Separate convenience functionality away, to make a clear distinction.
3. Eliminate the necessity for the mapping model to be separate from its own implementation.
4. Clean-up redundant code introduced in previous versions, and not identified.