### PR TITLE
Remove wrapping the Writer in a BufferedWriter in TextMappingsWriter

### DIFF
--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/TextMappingsWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/TextMappingsWriter.java
@@ -59,8 +59,7 @@ public abstract class TextMappingsWriter extends MappingsWriter {
         if (writer instanceof PrintWriter) {
             this.writer = (PrintWriter) writer;
         } else {
-            final BufferedWriter bufferedWriter = writer instanceof BufferedWriter ? (BufferedWriter) writer : new BufferedWriter(writer);
-            this.writer = new PrintWriter(bufferedWriter);
+            this.writer = new PrintWriter(writer);
         }
     }
 


### PR DESCRIPTION
This isn't needed and will cause issues if the output is longer than the buffer
can handle.