### PR TITLE
Include new mappings provided by the right side of a merge() call

### DIFF
--- a/lorenz/src/main/java/org/cadixdev/lorenz/impl/model/AbstractMemberMappingImpl.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/impl/model/AbstractMemberMappingImpl.java
@@ -75,7 +75,7 @@ public abstract class AbstractMemberMappingImpl<M extends MemberMapping<M, P>, P
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), this.parent);
+        return Objects.hash(super.hashCode(), this.parent.getFullObfuscatedName(), this.parent.getFullDeobfuscatedName());
     }
 
 }

--- a/lorenz/src/main/java/org/cadixdev/lorenz/impl/model/InnerClassMappingImpl.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/impl/model/InnerClassMappingImpl.java
@@ -106,7 +106,7 @@ public class InnerClassMappingImpl extends AbstractClassMappingImpl<InnerClassMa
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), this.parentClass);
+        return Objects.hash(super.hashCode(), this.parentClass.getFullObfuscatedName(), this.parentClass.getFullDeobfuscatedName());
     }
 
 }

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/InnerClassMapping.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/InnerClassMapping.java
@@ -25,6 +25,8 @@
 
 package org.cadixdev.lorenz.model;
 
+import java.util.HashSet;
+
 /**
  * Represents a de-obfuscation mapping for an inner class.
  *
@@ -98,18 +100,42 @@ public interface InnerClassMapping extends ClassMapping<InnerClassMapping, Class
         final InnerClassMapping newMapping = parent.getOrCreateInnerClassMapping(this.getObfuscatedName())
                 .setDeobfuscatedName(with.getDeobfuscatedName());
 
+        final HashSet<FieldMapping> fieldMappings = new HashSet<>();
+        final HashSet<MethodMapping> methodMappings = new HashSet<>();
+        final HashSet<InnerClassMapping> innerClassMappings = new HashSet<>();
+
         // fill with child data
         this.getFieldMappings().forEach(field -> {
             final FieldMapping fieldWith = with.getOrCreateFieldMapping(field.getDeobfuscatedSignature());
+            fieldMappings.add(fieldWith);
             field.merge(fieldWith, newMapping);
         });
         this.getMethodMappings().forEach(method -> {
             final MethodMapping methodWith = with.getOrCreateMethodMapping(method.getDeobfuscatedSignature());
+            methodMappings.add(methodWith);
             method.merge(methodWith, newMapping);
         });
         this.getInnerClassMappings().forEach(klass -> {
             final InnerClassMapping klassWith = with.getOrCreateInnerClassMapping(klass.getDeobfuscatedName());
+            innerClassMappings.add(klassWith);
             klass.merge(klassWith, newMapping);
+        });
+
+        // Include mappings added by with
+        with.getFieldMappings().forEach(field -> {
+            if (!fieldMappings.contains(field)) {
+                field.copy(newMapping);
+            }
+        });
+        with.getMethodMappings().forEach(method -> {
+            if (!methodMappings.contains(method))  {
+                method.copy(newMapping);
+            }
+        });
+        with.getInnerClassMappings().forEach(klass -> {
+            if (!innerClassMappings.contains(klass)) {
+                klass.copy(newMapping);
+            }
         });
 
         // A -> [B / C] -> D

--- a/lorenz/src/main/java/org/cadixdev/lorenz/model/TopLevelClassMapping.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/model/TopLevelClassMapping.java
@@ -25,6 +25,7 @@
 
 package org.cadixdev.lorenz.model;
 
+import java.util.HashSet;
 import org.cadixdev.lorenz.MappingSet;
 
 /**
@@ -88,18 +89,42 @@ public interface TopLevelClassMapping extends ClassMapping<TopLevelClassMapping,
         final TopLevelClassMapping newMapping = parent.getOrCreateTopLevelClassMapping(this.getObfuscatedName())
                 .setDeobfuscatedName(with.getDeobfuscatedName());
 
+        final HashSet<FieldMapping> fieldMappings = new HashSet<>();
+        final HashSet<MethodMapping> methodMappings = new HashSet<>();
+        final HashSet<InnerClassMapping> innerClassMappings = new HashSet<>();
+
         // fill with child data
         this.getFieldMappings().forEach(field -> {
             final FieldMapping fieldWith = with.getOrCreateFieldMapping(field.getDeobfuscatedSignature());
+            fieldMappings.add(fieldWith);
             field.merge(fieldWith, newMapping);
         });
         this.getMethodMappings().forEach(method -> {
             final MethodMapping methodWith = with.getOrCreateMethodMapping(method.getDeobfuscatedSignature());
+            methodMappings.add(methodWith);
             method.merge(methodWith, newMapping);
         });
         this.getInnerClassMappings().forEach(klass -> {
             final InnerClassMapping klassWith = with.getOrCreateInnerClassMapping(klass.getDeobfuscatedName());
+            innerClassMappings.add(klassWith);
             klass.merge(klassWith, newMapping);
+        });
+
+        // Include mappings added by with
+        with.getFieldMappings().forEach(field -> {
+            if (!fieldMappings.contains(field)) {
+                field.copy(newMapping);
+            }
+        });
+        with.getMethodMappings().forEach(method -> {
+            if (!methodMappings.contains(method))  {
+                method.copy(newMapping);
+            }
+        });
+        with.getInnerClassMappings().forEach(klass -> {
+            if (!innerClassMappings.contains(klass)) {
+                klass.copy(newMapping);
+            }
         });
 
         // A -> [B / C] -> D


### PR DESCRIPTION
In both InnerClassMapping and TopLevelClassMapping the merge methods are
implemented by looping over the members of the left side and merging
the value with the members on the right side. This properly handles both
new mappings provided by the left side, and mappings provided by both
sides. The only part it leaves out is new mappings provided by the right
side.

This commit accomplishes this by keeping track of the mappings which
have already been seen with HashSets during the iteration over the left
members, and then only applying new mappings from the right by iterating
over the right side and ignoring mappings we've already seen.

Since this commit now uses the hashCode methods, I also found a
recursive hashCode bug due to members trying to get the hashCode of
classes which contain said member. I fixed this by instead just hashing
the parent's names.