### PR TITLE
build: Make artifacts automatic modules

### DIFF
--- a/lorenz-dsl-groovy/build.gradle
+++ b/lorenz-dsl-groovy/build.gradle
@@ -8,3 +8,7 @@ javadoc {
             'http://docs.groovy-lang.org/2.5.8/html/gapi/'
     )
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz.dsl.groovy")
+}

--- a/lorenz-io-enigma/build.gradle
+++ b/lorenz-io-enigma/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
     compile project(':lorenz')
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz.io.enigma")
+}

--- a/lorenz-io-gson/build.gradle
+++ b/lorenz-io-gson/build.gradle
@@ -3,3 +3,7 @@ dependencies {
     compile 'com.google.code.gson:gson:2.8.6'
     compile 'me.jamiemansfield:gson-simple:0.1.1'
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz.io.gson")
+}

--- a/lorenz-io-jam/build.gradle
+++ b/lorenz-io-jam/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
     compile project(':lorenz')
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz.io.jam")
+}

--- a/lorenz-io-kin/build.gradle
+++ b/lorenz-io-kin/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
     compile project(':lorenz')
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz.io.kin")
+}

--- a/lorenz-io-proguard/build.gradle
+++ b/lorenz-io-proguard/build.gradle
@@ -1,3 +1,7 @@
 dependencies {
     compile project(':lorenz')
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz.io.proguard")
+}

--- a/lorenz/build.gradle
+++ b/lorenz/build.gradle
@@ -17,3 +17,7 @@ javadoc {
             'https://docs.oracle.com/javase/8/docs/api/'
     )
 }
+
+jar {
+    manifest.attributes("Automatic-Module-Name": "${project.group}.lorenz")
+}


### PR DESCRIPTION
As in the other projects, lets Lorenz be used as a direct dependency of a full Java 9+ module.