### PR TITLE
Writer configurations

### DIFF
--- a/changelogs/0.5.5.md
+++ b/changelogs/0.5.5.md
@@ -1,2 +1,31 @@
 Lorenz 0.5.5
 ============
+
+## Writer configurations
+
+Writer configurations are a powerful new feature that allows the output of
+mappings writers to be fine-tuned as consumers would like. Currently, this
+is limited to:
+
+- The sorting functions used to write mappings for classes, fields, and
+  methods.
+- The API is open-ended, so there is potential for further additions to be
+  made.
+
+Writer configurations can be created fluently through use the provided
+builder, which includes our default implementations.
+
+```java
+protected MappingsWriterConfig config = MappingsWriterConfig.builder()
+        .classMappingComparator(Comparator.comparing(Mapping::getFullObfuscatedName))
+        .fieldMappingComparator(Comparator.comparing(Mapping::getFullObfuscatedName))
+        .methodMappingComparator(Comparator.comparing(Mapping::getFullObfuscatedName))
+        .build();
+```
+
+They are applied to a mappings writer by use of the new `#setConfig` method,
+and can be retrieved through the corresponding `#getConfig()` method.
+
+```java
+writer.setConfig(MappingsWriterConfig.builder().build());
+```

--- a/lorenz-io-enigma/src/main/java/org/cadixdev/lorenz/io/enigma/EnigmaWriter.java
+++ b/lorenz-io-enigma/src/main/java/org/cadixdev/lorenz/io/enigma/EnigmaWriter.java
@@ -95,7 +95,7 @@ public class EnigmaWriter extends TextMappingsWriter {
     public void write(final MappingSet mappings) throws IOException {
         mappings.getTopLevelClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(klass -> this.writeClassMapping(klass, 0));
     }
 
@@ -114,19 +114,19 @@ public class EnigmaWriter extends TextMappingsWriter {
         // Write inner class mappings
         klass.getInnerClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(inner -> this.writeClassMapping(inner, indent + 1));
 
         // Write field mappings
         klass.getFieldMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_FIELDS)
+                .sorted(this.getConfig().getFieldMappingComparator())
                 .forEach(field -> this.writeFieldMapping(field, indent + 1));
 
         // Write method mappings
         klass.getMethodMappings().stream()
                 .filter(MethodMapping::hasMappings)
-                .sorted(ALPHABETISE_METHODS)
+                .sorted(this.getConfig().getMethodMappingComparator())
                 .forEach(method -> this.writeMethodMapping(method, indent + 1));
     }
 

--- a/lorenz-io-jam/src/main/java/org/cadixdev/lorenz/io/jam/JamWriter.java
+++ b/lorenz-io-jam/src/main/java/org/cadixdev/lorenz/io/jam/JamWriter.java
@@ -61,7 +61,7 @@ public class JamWriter extends TextMappingsWriter {
         // Write class mappings
         mappings.getTopLevelClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write everything to the print writer
@@ -89,19 +89,19 @@ public class JamWriter extends TextMappingsWriter {
         // Write inner class mappings
         mapping.getInnerClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write field mappings
         mapping.getFieldMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_FIELDS)
+                .sorted(this.getConfig().getFieldMappingComparator())
                 .forEach(this::writeFieldMapping);
 
         // Write method mappings
         mapping.getMethodMappings().stream()
                 .filter(MethodMapping::hasMappings)
-                .sorted(ALPHABETISE_METHODS)
+                .sorted(this.getConfig().getMethodMappingComparator())
                 .forEach(this::writeMethodMapping);
     }
 

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingFormat.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingFormat.java
@@ -130,6 +130,23 @@ public interface MappingFormat {
     }
 
     /**
+     * Writes a mapping set to file, applying the given
+     * {@link MappingsWriterConfig writer configuration} before writing.
+     *
+     * @param mappings The mapping set to write
+     * @param path The path of the mappings file
+     * @param config The writer configuration
+     * @throws IOException Should an I/O issue occur
+     * @since 0.5.5
+     */
+    default void write(final MappingSet mappings, final Path path, final MappingsWriterConfig config) throws IOException {
+        try (final MappingsWriter writer = this.createWriter(path)) {
+            writer.setConfig(config);
+            writer.write(mappings);
+        }
+    }
+
+    /**
      * Gets the typically used file extension for the format, if available.
      *
      * @return The standard file extension

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriter.java
@@ -39,7 +39,7 @@ import java.util.function.Function;
 /**
  * Represents a writer, that is capable of writing de-obfuscation
  * mappings.
- *
+ * <p>
  * Each mappings writer will be designed for a specific mapping
  * format, and intended to be used with try-for-resources.
  *
@@ -53,7 +53,11 @@ public abstract class MappingsWriter implements Closeable {
 
     /**
      * A {@link Comparator} used to alphabetise a collection of {@link Mapping}s.
+     *
+     * @deprecated 0.5.5 Use {@link #getConfig()} {@link MappingsWriterConfig#getClassMappingComparator()}
+     *             instead
      */
+    @Deprecated
     protected static final Comparator<Mapping> ALPHABETISE_MAPPINGS =
             comparingLength(Mapping::getFullObfuscatedName);
 
@@ -61,7 +65,10 @@ public abstract class MappingsWriter implements Closeable {
      * A {@link Comparator} used to alphabetise a collection of {@link FieldMapping}s.
      *
      * @since 0.5.0
+     * @deprecated 0.5.5 Use {@link #getConfig()} {@link MappingsWriterConfig#getFieldMappingComparator()}
+     *             instead
      */
+    @Deprecated
     protected static final Comparator<FieldMapping> ALPHABETISE_FIELDS =
             Comparator.comparing(mapping -> mapping.getFullObfuscatedName() + mapping.getType().map(FieldType::toString).orElse(""));
 
@@ -69,7 +76,10 @@ public abstract class MappingsWriter implements Closeable {
      * A {@link Comparator} used to alphabetise a collection of {@link MethodMapping}s.
      *
      * @since 0.5.0
+     * @deprecated 0.5.5 Use {@link #getConfig()} {@link MappingsWriterConfig#getMethodMappingComparator()}
+     *             instead
      */
+    @Deprecated
     protected static final Comparator<MethodMapping> ALPHABETISE_METHODS =
             Comparator.comparing(mapping -> mapping.getFullObfuscatedName() + mapping.getDescriptor().toString());
 
@@ -82,6 +92,36 @@ public abstract class MappingsWriter implements Closeable {
             }
             return key1.compareTo(key2);
         };
+    }
+
+    protected MappingsWriterConfig config = MappingsWriterConfig.builder().build();
+
+    /**
+     * Gets the active {@link MappingsWriterConfig writer configuration} for
+     * this mappings writer.
+     *
+     * @return The writer configuration
+     * @since 0.5.5
+     */
+    public MappingsWriterConfig getConfig() {
+        return this.config;
+    }
+
+    /**
+     * Sets the active {@link MappingsWriterConfig writer configuration} for
+     * this mappings writer - allowing the output of the writer to be fine-tuned
+     * to fit the environment in use.
+     *
+     * @param config The writer configuration
+     * @throws IllegalArgumentException If {@code config} is {@code null}
+     * @since 0.5.5
+     */
+    public void setConfig(final MappingsWriterConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("config cannot be null!");
+        }
+
+        this.config = config;
     }
 
     /**

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriter.java
@@ -113,12 +113,12 @@ public abstract class MappingsWriter implements Closeable {
      * to fit the environment in use.
      *
      * @param config The writer configuration
-     * @throws IllegalArgumentException If {@code config} is {@code null}
+     * @throws NullPointerException If {@code config} is {@code null}
      * @since 0.5.5
      */
     public void setConfig(final MappingsWriterConfig config) {
         if (config == null) {
-            throw new IllegalArgumentException("config cannot be null!");
+            throw new NullPointerException("config cannot be null!");
         }
 
         this.config = config;

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriterConfig.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriterConfig.java
@@ -1,0 +1,197 @@
+/*
+ * This file is part of Lorenz, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Jamie Mansfield <https://www.jamierocks.uk/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.cadixdev.lorenz.io;
+
+import org.cadixdev.bombe.type.FieldType;
+import org.cadixdev.lorenz.model.ClassMapping;
+import org.cadixdev.lorenz.model.FieldMapping;
+import org.cadixdev.lorenz.model.Mapping;
+import org.cadixdev.lorenz.model.MethodMapping;
+
+import java.util.Comparator;
+import java.util.function.Function;
+
+/**
+ * Represents the configuration options for a {@link MappingsWriter mappings writer},
+ * allowing consumers to fine-tune the output without regard to format.
+ *
+ * @author Jamie Mansfield
+ * @since 0.5.5
+ */
+public class MappingsWriterConfig {
+
+    /**
+     * Creates a new builder for fluently constructing a writer
+     * configuration.
+     *
+     * @return A builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final Comparator<ClassMapping<?, ?>> classMappingComparator;
+    private final Comparator<FieldMapping> fieldMappingComparator;
+    private final Comparator<MethodMapping> methodMappingComparator;
+
+    MappingsWriterConfig(final Builder builder) {
+        this.classMappingComparator = builder.classMappingComparator;
+        this.fieldMappingComparator = builder.fieldMappingComparator;
+        this.methodMappingComparator = builder.methodMappingComparator;
+    }
+
+    /**
+     * Gets the class mapping comparator for arranging class mappings
+     * when writing mappings.
+     *
+     * @return The class mappings comparator
+     */
+    public Comparator<ClassMapping<?, ?>> getClassMappingComparator() {
+        return this.classMappingComparator;
+    }
+
+    /**
+     * Gets the field mapping comparator for arranging field mappings
+     * when writing mappings.
+     *
+     * @return The field mappings comparator
+     */
+    public Comparator<FieldMapping> getFieldMappingComparator() {
+        return this.fieldMappingComparator;
+    }
+
+    /**
+     * Gets the method mapping comparator for arranging method mappings
+     * when writing mappings.
+     *
+     * @return The method mappings comparator
+     */
+    public Comparator<MethodMapping> getMethodMappingComparator() {
+        return this.methodMappingComparator;
+    }
+
+    /**
+     * Builder for fluently constructing a writer configuration.
+     * <p>
+     * There is a designated {@link #builder()} function intended for
+     * creating a new builder - however consumers may also directly
+     * construct a builder.
+     */
+    public static class Builder {
+
+        private Comparator<ClassMapping<?, ?>> classMappingComparator =
+                Utils.comparingLength(Mapping::getFullObfuscatedName);
+
+        private Comparator<FieldMapping> fieldMappingComparator =
+                Comparator.comparing(mapping -> mapping.getFullObfuscatedName() + mapping.getType().map(FieldType::toString).orElse(""));
+
+        private Comparator<MethodMapping> methodMappingComparator =
+                Comparator.comparing(mapping -> mapping.getFullObfuscatedName() + mapping.getDescriptor().toString());
+
+        /**
+         * Sets the class mapping comparator to be used for writing mappings.
+         *
+         * @param classMappingComparator The class mapping comparator
+         */
+        public void classMappingComparator(final Comparator<ClassMapping<?, ?>> classMappingComparator) {
+            if (classMappingComparator == null) {
+                throw new IllegalArgumentException("classMappingComparator cannot be null!");
+            }
+
+            this.classMappingComparator = classMappingComparator;
+        }
+
+        /**
+         * Sets the field mapping comparator to be used for writing mappings.
+         *
+         * @param fieldMappingComparator The field mapping comparator
+         */
+        public void fieldMappingComparator(final Comparator<FieldMapping> fieldMappingComparator) {
+            if (fieldMappingComparator == null) {
+                throw new IllegalArgumentException("fieldMappingComparator cannot be null!");
+            }
+
+            this.fieldMappingComparator = fieldMappingComparator;
+        }
+
+        /**
+         * Sets the method mapping comparator to be used for writing mappings.
+         *
+         * @param methodMappingComparator The method mapping comparator
+         */
+        public void methodMappingComparator(final Comparator<MethodMapping> methodMappingComparator) {
+            if (methodMappingComparator == null) {
+                throw new IllegalArgumentException("methodMappingComparator cannot be null!");
+            }
+
+            this.methodMappingComparator = methodMappingComparator;
+        }
+
+        /**
+         * Creates a writer configuration, using the values previously supplied.
+         *
+         * @return The writer configuration
+         */
+        public MappingsWriterConfig build() {
+            return new MappingsWriterConfig(this);
+        }
+
+    }
+
+    /**
+     * Utility functions for assisting in the creation of a mappings
+     * writer configuration.
+     */
+    public static class Utils {
+
+        /**
+         * Accepts a function that extracts a string sort key from a type {@code T},
+         * and returns a {@link Comparator comparator} that compares using that key
+         * when the lengths are both equal, and comparing based on length otherwise.
+         *
+         * @param keyExtractor The function used to extract the sort key
+         * @param <T> The type of the object being compared
+         * @return The comparator
+         */
+        public static <T> Comparator<T> comparingLength(final Function<? super T, String> keyExtractor) {
+            return (c1, c2) -> {
+                final String key1 = keyExtractor.apply(c1);
+                final String key2 = keyExtractor.apply(c2);
+
+                if (key1.length() != key2.length()) {
+                    return key1.length() - key2.length();
+                }
+
+                return key1.compareTo(key2);
+            };
+        }
+
+        private Utils() {
+        }
+
+    }
+
+}

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriterConfig.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriterConfig.java
@@ -115,11 +115,12 @@ public class MappingsWriterConfig {
          * Sets the class mapping comparator to be used for writing mappings.
          *
          * @param classMappingComparator The class mapping comparator
+         * @throws NullPointerException If {@code classMappingComparator} is {@code null}
          * @return {@code this} for chaining
          */
         public Builder classMappingComparator(final Comparator<ClassMapping<?, ?>> classMappingComparator) {
             if (classMappingComparator == null) {
-                throw new IllegalArgumentException("classMappingComparator cannot be null!");
+                throw new NullPointerException("classMappingComparator cannot be null!");
             }
 
             this.classMappingComparator = classMappingComparator;
@@ -130,11 +131,12 @@ public class MappingsWriterConfig {
          * Sets the field mapping comparator to be used for writing mappings.
          *
          * @param fieldMappingComparator The field mapping comparator
+         * @throws NullPointerException If {@code fieldMappingComparator} is {@code null}
          * @return {@code this} for chaining
          */
         public Builder fieldMappingComparator(final Comparator<FieldMapping> fieldMappingComparator) {
             if (fieldMappingComparator == null) {
-                throw new IllegalArgumentException("fieldMappingComparator cannot be null!");
+                throw new NullPointerException("fieldMappingComparator cannot be null!");
             }
 
             this.fieldMappingComparator = fieldMappingComparator;
@@ -145,11 +147,12 @@ public class MappingsWriterConfig {
          * Sets the method mapping comparator to be used for writing mappings.
          *
          * @param methodMappingComparator The method mapping comparator
+         * @throws NullPointerException If {@code methodMappingComparator} is {@code null}
          * @return {@code this} for chaining
          */
         public Builder methodMappingComparator(final Comparator<MethodMapping> methodMappingComparator) {
             if (methodMappingComparator == null) {
-                throw new IllegalArgumentException("methodMappingComparator cannot be null!");
+                throw new NullPointerException("methodMappingComparator cannot be null!");
             }
 
             this.methodMappingComparator = methodMappingComparator;

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriterConfig.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/MappingsWriterConfig.java
@@ -115,39 +115,45 @@ public class MappingsWriterConfig {
          * Sets the class mapping comparator to be used for writing mappings.
          *
          * @param classMappingComparator The class mapping comparator
+         * @return {@code this} for chaining
          */
-        public void classMappingComparator(final Comparator<ClassMapping<?, ?>> classMappingComparator) {
+        public Builder classMappingComparator(final Comparator<ClassMapping<?, ?>> classMappingComparator) {
             if (classMappingComparator == null) {
                 throw new IllegalArgumentException("classMappingComparator cannot be null!");
             }
 
             this.classMappingComparator = classMappingComparator;
+            return this;
         }
 
         /**
          * Sets the field mapping comparator to be used for writing mappings.
          *
          * @param fieldMappingComparator The field mapping comparator
+         * @return {@code this} for chaining
          */
-        public void fieldMappingComparator(final Comparator<FieldMapping> fieldMappingComparator) {
+        public Builder fieldMappingComparator(final Comparator<FieldMapping> fieldMappingComparator) {
             if (fieldMappingComparator == null) {
                 throw new IllegalArgumentException("fieldMappingComparator cannot be null!");
             }
 
             this.fieldMappingComparator = fieldMappingComparator;
+            return this;
         }
 
         /**
          * Sets the method mapping comparator to be used for writing mappings.
          *
          * @param methodMappingComparator The method mapping comparator
+         * @return {@code this} for chaining
          */
-        public void methodMappingComparator(final Comparator<MethodMapping> methodMappingComparator) {
+        public Builder methodMappingComparator(final Comparator<MethodMapping> methodMappingComparator) {
             if (methodMappingComparator == null) {
                 throw new IllegalArgumentException("methodMappingComparator cannot be null!");
             }
 
             this.methodMappingComparator = methodMappingComparator;
+            return this;
         }
 
         /**

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/SrgWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/SrgWriter.java
@@ -63,7 +63,7 @@ public class SrgWriter extends TextMappingsWriter {
         // Write class mappings
         mappings.getTopLevelClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write everything to the print writer
@@ -91,19 +91,19 @@ public class SrgWriter extends TextMappingsWriter {
         // Write inner class mappings
         mapping.getInnerClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write field mappings
         mapping.getFieldsByName().values().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_FIELDS)
+                .sorted(this.getConfig().getFieldMappingComparator())
                 .forEach(this::writeFieldMapping);
 
         // Write method mappings
         mapping.getMethodMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_METHODS)
+                .sorted(this.getConfig().getMethodMappingComparator())
                 .forEach(this::writeMethodMapping);
     }
 

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/csrg/CSrgWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/csrg/CSrgWriter.java
@@ -63,7 +63,7 @@ public class CSrgWriter extends TextMappingsWriter {
         // Write class mappings
         mappings.getTopLevelClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write everything to the print writer
@@ -91,19 +91,19 @@ public class CSrgWriter extends TextMappingsWriter {
         // Write inner class mappings
         mapping.getInnerClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write field mappings
         mapping.getFieldsByName().values().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_FIELDS)
+                .sorted(this.getConfig().getFieldMappingComparator())
                 .forEach(this::writeFieldMapping);
 
         // Write method mappings
         mapping.getMethodMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_METHODS)
+                .sorted(this.getConfig().getMethodMappingComparator())
                 .forEach(this::writeMethodMapping);
     }
 

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/tsrg/TSrgWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/tsrg/TSrgWriter.java
@@ -57,7 +57,7 @@ public class TSrgWriter extends TextMappingsWriter {
         // Write class mappings
         mappings.getTopLevelClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
     }
 
@@ -77,19 +77,19 @@ public class TSrgWriter extends TextMappingsWriter {
         // Write field mappings
         mapping.getFieldsByName().values().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_FIELDS)
+                .sorted(this.getConfig().getFieldMappingComparator())
                 .forEach(this::writeFieldMapping);
 
         // Write method mappings
         mapping.getMethodMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_METHODS)
+                .sorted(this.getConfig().getMethodMappingComparator())
                 .forEach(this::writeMethodMapping);
 
         // Write inner class mappings
         mapping.getInnerClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
     }
 

--- a/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/xsrg/XSrgWriter.java
+++ b/lorenz/src/main/java/org/cadixdev/lorenz/io/srg/xsrg/XSrgWriter.java
@@ -65,7 +65,7 @@ public class XSrgWriter extends TextMappingsWriter {
         // Write class mappings
         mappings.getTopLevelClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write everything to the print writer
@@ -93,19 +93,19 @@ public class XSrgWriter extends TextMappingsWriter {
         // Write inner class mappings
         mapping.getInnerClassMappings().stream()
                 .filter(ClassMapping::hasMappings)
-                .sorted(ALPHABETISE_MAPPINGS)
+                .sorted(this.getConfig().getClassMappingComparator())
                 .forEach(this::writeClassMapping);
 
         // Write field mappings
         mapping.getFieldMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_FIELDS)
+                .sorted(this.getConfig().getFieldMappingComparator())
                 .forEach(this::writeFieldMapping);
 
         // Write method mappings
         mapping.getMethodMappings().stream()
                 .filter(Mapping::hasDeobfuscatedName)
-                .sorted(ALPHABETISE_METHODS)
+                .sorted(this.getConfig().getMethodMappingComparator())
                 .forEach(this::writeMethodMapping);
     }
 


### PR DESCRIPTION
Writer configurations are a powerful new feature that allows the output of
mappings writers to be fine-tuned as consumers would like. Currently, this
is limited to:

- The sorting functions used to write mappings for classes, fields, and
  methods.
- The API is open-ended, so there is potential for further additions to be
  made.

Writer configurations can be created fluently through use the provided
builder, which includes our default implementations.

```java
protected MappingsWriterConfig config = MappingsWriterConfig.builder()
        .classMappingComparator(Comparator.comparing(Mapping::getFullObfuscatedName))
        .fieldMappingComparator(Comparator.comparing(Mapping::getFullObfuscatedName))
        .methodMappingComparator(Comparator.comparing(Mapping::getFullObfuscatedName))
        .build();
```

They are applied to a mappings writer by use of the new `#setConfig` method,
and can be retrieved through the corresponding `#getConfig()` method.

```java
writer.setConfig(MappingsWriterConfig.builder().build());
```