### PR TITLE
Allow any method parameter index

### DIFF
--- a/changelogs/0.5.6.md
+++ b/changelogs/0.5.6.md
@@ -13,3 +13,18 @@ This release just adds one new method to [`MergeConfig`](https://github.com/Cadi
 [`getParallelism()`](https://github.com/CadixDev/Lorenz/blob/49be5233bff0adfaf59440ac37efdeccbb2893da/lorenz/src/main/java/org/cadixdev/lorenz/merge/MergeConfig.java#L84-L95).
 Set this value using the new [`withParallelism()`](https://github.com/CadixDev/Lorenz/blob/49be5233bff0adfaf59440ac37efdeccbb2893da/lorenz/src/main/java/org/cadixdev/lorenz/merge/MergeConfig.java#L185-L202)
 method. Check the javadocs for more info.
+
+Allow arbitrary indexes for parameter mappings 
+---------------------------------------------
+
+Method mappings may now contain parameter mappings for arbitrary indexes, rather than being constrained to
+between 0 and the number of parameters in the method signature. This is nice from a general flexibility
+perspective as Lorenz is only a container and isn't intended for validating mappings, but also fixes the issue
+where Lorenz can't read mappings which using 1-indexed method parameters for instance methods. With this change
+it's up to the user to decide how to use parameter mappings, Lorenz doesn't dictate anything one way or the
+other (just like the other mapping types).
+
+Any code which worked with Lorenz before will still continue to work, as this change only removes constraints
+which used to be present. If some code was written which relied on the existing index checks then this will
+technically be a breaking change, as you'll need to handle those checks yourself. That is likely to be a minor
+edge case however, so this is still considered a minor release.


### PR DESCRIPTION
The previous implementation required all method parameter indexes be
within the range for the parameters of the method mapping based on the
method signature. This commit changes the behavior to instead allow any
parameter index provided.

There are two arguments for allowing this behavior:

 1. Some mapping formats have different meanings for the index
    parameters, and Lorenz has no way of handling them other than taking
    the parameter index as-is. The most common example is static methods
    starting to count method parameters at 0, while instance methods
    start at 1 (as `this` is index 0). Lorenz has no way of knowing a
    method is static or not, and even if it did it can't be guaranteed
    that every mapping format behaves the same way.

 2. All other mappings (top-level class, field, method, and inner class
    mappings) have no way to verify, and don't verify, if the mapping is
    valid. A method parameter index outside of the parameter index range
    is very similar to a field mapping in a class which doesn't contain
    a field of that name. It's Lorenz's job to verify mappings are
    valid, only to store them as given and reproduce them later.

There's definitely a risk here that 1 mapping format may want 0-indexed
parameter mappings for all methods, whereas another mapping format wants
the above strategy of using 1-indexed mappings for instance methods, but
I don't see a viable solution for handling cases like these.

In situations where parameter mappings are needed it's likely that the
mapping format will not change, or if it does then it is up to the user
to handle it one way or the other. Lorenz is just a mapping container,
it can't perfectly handle all cases. But as long as it provides a
flexible model and allows the user to insert the mappings it needs,
then the user can write whatever code they need to to handle whichever
situation they run into.